### PR TITLE
Merge fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Install
     [Intercom setApiKey:@"<#ios_sdk-...#>" forAppId:@"<#your-app-id#>"];
 }
 ```
+6. [Intercom's documentation](https://github.com/intercom/intercom-ios/blob/1fe2e92c4913e4ffef290b5b62dac5ecef74ea1d/Intercom.framework/Versions/A/Headers/Intercom.h#L65) suggests adding the following call in order to receive push notifications for new messages:
+```
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+     [Intercom setDeviceToken:deviceToken];
+}
+```
 
 Usage
 =====

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -152,11 +152,6 @@ RCT_EXPORT_METHOD(registerForPush:(RCTResponseSenderBlock)callback) {
       UIRemoteNotificationTypeSound |
       UIRemoteNotificationTypeAlert)];
   }
-  
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [Intercom registerForRemoteNotifications];
-  #pragma GCC diagnostic pop
 
   callback(@[[NSNull null]]);
 };


### PR DESCRIPTION
…(fixes #5)

Signed-off-by: Tal Kain tal@kain.net

The function registerForRemoteNotifications was deprecated since v2.1 and was
removed in Intercom v2.3.5 API.
setDeviceToken should be called instead of registerForRemoteNotifications.
